### PR TITLE
Update to v1.2.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .Rhistory
 .RData
 .Ruserdata
+*.pdf

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qualcontrol
 Title: Quality Control
-Version: 1.2.3.9000
+Version: 1.2.4
 Authors@R: 
     person("Vegard", "Lysne", , "vegard.lysne@helsedir.no", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-0816-5075"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qualcontrol
 Title: Quality Control
-Version: 1.2.3
+Version: 1.2.3.9000
 Authors@R: 
     person("Vegard", "Lysne", , "vegard.lysne@helsedir.no", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-0816-5075"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 # qualcontrol (development version)
+* In plotting functions, `archive_old_files()` now matches on cube name and not cube file (including date tag) to archive all old files
 * Bug fixed in `compare_geolevels()` where missing data interfered with checking if any lower level > higher level. 
 * `is_valid_outcols()` only applied if data file is not censored on geo.
 * sets overid = 0 in all functions using collapse::join, to prevent overidentification of joins. 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # qualcontrol (development version)
 * sets overid = 0 in all functions using collapse::join, to prevent overidentification of joins. 
 * `plot_boxplot()`, `plot_timeseries_country()`, and `plot_diff_timetrends()` now prints the plot in the console.
+* `compare_geolevels()` prints a message if lower geographical level > higher geographical level, e.g. kommune > fylke. 
 
 # qualcontrol 1.2.3
 * Fixed bug where `diffvals_summary(byyear = TRUE)` only displayed first 10 years in long time series.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
 # qualcontrol (development version)
+* Bug fixed in `compare_geolevels()` where missing data interfered with checking if any lower level > higher level. 
+* `is_valid_outcols()` only applied if data file is not censored on geo.
 * sets overid = 0 in all functions using collapse::join, to prevent overidentification of joins. 
 * `plot_boxplot()`, `plot_timeseries_country()`, `plot_timeseries_bydel()`, and `plot_diff_timetrends()` now prints the plot in the console.
 * `compare_geolevels()` prints a message if lower geographical level > higher geographical level, e.g. kommune > fylke. 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,35 +1,62 @@
-# qualcontrol (development version)
-* `plot_timeseries()` correctly shows GEO-codes in the plots
-* In plotting functions, `archive_old_files()` now matches on cube name and not cube file (including date tag) to archive all old files
-* Bug fixed in `compare_geolevels()` where missing data interfered with checking if any lower level > higher level. 
-* `is_valid_outcols()` only applied if data file is not censored on geo.
-* sets overid = 0 in all functions using collapse::join, to prevent overidentification of joins. 
-* `plot_boxplot()`, `plot_timeseries_country()`, `plot_timeseries_bydel()`, and `plot_diff_timetrends()` now prints the plot in the console.
-* `compare_geolevels()` prints a message if lower geographical level > higher geographical level, e.g. kommune > fylke. 
+# qualcontrol 1.2.4
+
+## New features
+
+1. `plot_boxplot()`, `plot_timeseries_country()`, `plot_timeseries_bydel()`, and `plot_diff_timetrends()` now prints the plot in the console.
+2. `compare_geolevels()` prints a message if lower geographical level > higher geographical level, e.g. kommune > fylke. 
+
+## Bugfixes
+
+1. `add_changeval()` adds a small constant equal to half of the minimum non-zero value of the outlier variable. This prevents Inf-values for change variables in the flagged cube.
+2. `plot_timeseries()` correctly shows GEO-codes in the plots
+3. In plotting functions, `archive_old_files()` now matches on cube name and not cube file (including date tag) to archive all old files
+4. Bug fixed in `compare_geolevels()` where missing data interfered with checking if any lower level > higher level. 
+5. `is_valid_outcols()` only applied if data file is not censored on geo.
+6. In all functions using collapse::join, overid is set to 0 to prevent overidentification of joins. 
 
 # qualcontrol 1.2.3
-* Fixed bug where `diffvals_summary(byyear = TRUE)` only displayed first 10 years in long time series.
+
+## Bugfixes
+
+1. Fixed bug where `diffvals_summary(byyear = TRUE)` only displayed first 10 years in long time series.
 
 # qualcontrol 1.2.2
-* Fixed bug where `split_kommuneniv()` failed when GEOniv == "K" was not present in data.
+
+## Bugfixes
+
+1. Fixed bug where `split_kommuneniv()` failed when GEOniv == "K" was not present in data.
 
 # qualcontrol 1.2.1
-* add tests for friskvik and barometer 
-* `plot_diff_timetrends()` now archives old plots if existing. 
-* Fixed bug in `plot_timeseries_country` where no plot was produced for dimensions with > 9 categories. 
+
+## New features
+
+1. add tests for friskvik and barometer 
+
+## Bugfixes
+
+1. `plot_diff_timetrends()` now archives old plots if existing. 
+2. Fixed bug in `plot_timeseries_country` where no plot was produced for dimensions with > 9 categories. 
 
 # qualcontrol 1.2.0
-* `plot_timeseries_country()` now generate a total plot, where all dimensions except AAR are aggregated (#1)
-* `check_friskvik()` function added (#2)
-* `check_barometer()` function added (#3)
-* `plot_timeseries_bydel()` now handles situations where GEO and AAR are the only dimensions present (#4)
-* `archive_old_plots()` renamed to `archive_old_files()`, for future implementation for file dumps. 
+
+## New features
+
+1. `plot_timeseries_country()` now generate a total plot, where all dimensions except AAR are aggregated (#1)
+2. `check_friskvik()` function added (#2)
+3. `check_barometer()` function added (#3)
+4. `archive_old_plots()` renamed to `archive_old_files()`, for future implementation for file dumps. 
+
+## Bugfixes
+1. `plot_timeseries_bydel()` now handles situations where GEO and AAR are the only dimensions present (#4)
 
 # qualcontrol 1.1.0
-* Added `diffvals_summary()`
-* `comparecube` now gets the `any_diffs` column indicating whether any diff column != 0
-* `comparecube` now handles expired and new dimensions
+
+## New features
+
+1. Added `diffvals_summary()`
+2. `comparecube` now gets the `any_diffs` column indicating whether any diff column != 0
+3. `comparecube` now handles expired and new dimensions
 
 # qualcontrol 1.0.0
 
-* Implemented all functions from KHvalitetskontroll del 1 and del 2.
+Implemented all functions from KHvalitetskontroll del 1 and del 2.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # qualcontrol (development version)
 * sets overid = 0 in all functions using collapse::join, to prevent overidentification of joins. 
+* `plot_boxplot()`, `plot_timeseries_country()`, and `plot_diff_timetrends()` now prints the plot in the console.
 
 # qualcontrol 1.2.3
 * Fixed bug where `diffvals_summary(byyear = TRUE)` only displayed first 10 years in long time series.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
+# qualcontrol (development version)
+* sets overid = 0 in all functions using collapse::join, to prevent overidentification of joins. 
+
 # qualcontrol 1.2.3
 * Fixed bug where `diffvals_summary(byyear = TRUE)` only displayed first 10 years in long time series.
+
 # qualcontrol 1.2.2
 * Fixed bug where `split_kommuneniv()` failed when GEOniv == "K" was not present in data.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 # qualcontrol (development version)
+* `plot_timeseries()` correctly shows GEO-codes in the plots
 * In plotting functions, `archive_old_files()` now matches on cube name and not cube file (including date tag) to archive all old files
 * Bug fixed in `compare_geolevels()` where missing data interfered with checking if any lower level > higher level. 
 * `is_valid_outcols()` only applied if data file is not censored on geo.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # qualcontrol (development version)
 * sets overid = 0 in all functions using collapse::join, to prevent overidentification of joins. 
-* `plot_boxplot()`, `plot_timeseries_country()`, and `plot_diff_timetrends()` now prints the plot in the console.
+* `plot_boxplot()`, `plot_timeseries_country()`, `plot_timeseries_bydel()`, and `plot_diff_timetrends()` now prints the plot in the console.
 * `compare_geolevels()` prints a message if lower geographical level > higher geographical level, e.g. kommune > fylke. 
 
 # qualcontrol 1.2.3

--- a/R/check-censoring.R
+++ b/R/check-censoring.R
@@ -114,7 +114,7 @@ compare_censoring <- function(cube.new = newcube,
 
   new <- cube.new[, .("N (new)" = .N), keyby = c("SPVFLAGG", by)]
   old <- cube.old[, .("N (old)" = .N), keyby = c("SPVFLAGG", by)]
-  output <- collapse::join(new, old, on = c("SPVFLAGG", by), how = "left", verbose = 0)
+  output <- collapse::join(new, old, on = c("SPVFLAGG", by), how = "left", verbose = 0, overid = 0)
 
   cols <- c("N (new)", "N (old)")
   output[, (cols) := lapply(.SD, collapse::replace_na, 0), .SDcols = cols]

--- a/R/check-comparecube.R
+++ b/R/check-comparecube.R
@@ -107,7 +107,7 @@ plot_diff_timetrends <- function(dt = comparecube,
   allyears <- get_all_combinations(d, c("GEOniv", "AAR", "variable"))
   d <- d[!(variable == "Absolute" & value == 0 | variable == "Relative" & value == 1)]
 
-  plotdata <- collapse::join(allyears, d, on = c("GEOniv", "AAR", "variable"), how = "left", multiple = T, verbose = 0)
+  plotdata <- collapse::join(allyears, d, on = c("GEOniv", "AAR", "variable"), how = "left", multiple = T, verbose = 0, overid = 0)
   xsize <- ifelse(length(unique(plotdata$AAR)) > 12, 10, 20)
   savepath <- get_plotsavefolder(cubename, "Diff_timetrends")
   if(save) archive_old_files(savepath, cubefile)

--- a/R/check-comparecube.R
+++ b/R/check-comparecube.R
@@ -106,6 +106,7 @@ plot_diff_timetrends <- function(dt = comparecube,
   d <- data.table::melt(d, measure.vars = c("Absolute", "Relative"))[, .(GEOniv, AAR, variable, value)]
   allyears <- get_all_combinations(d, c("GEOniv", "AAR", "variable"))
   d <- d[!(variable == "Absolute" & value == 0 | variable == "Relative" & value == 1)]
+  if(nrow(d) == 0) return("No rows with diffs, no plots generated")
 
   plotdata <- collapse::join(allyears, d, on = c("GEOniv", "AAR", "variable"), how = "left", multiple = T, verbose = 0, overid = 0)
   xsize <- ifelse(length(unique(plotdata$AAR)) > 12, 10, 20)
@@ -116,6 +117,7 @@ plot_diff_timetrends <- function(dt = comparecube,
     subset <- plotdata[GEOniv == geoniv]
     plot <- plot_diff_timetrends_plotfun(subset, geoniv, labelval, xsize)
     plot_diff_timetrends_savefun(plot, savepath, cubefile, geoniv, save = save)
+    print(plot)
   }
 }
 

--- a/R/check-comparecube.R
+++ b/R/check-comparecube.R
@@ -111,7 +111,7 @@ plot_diff_timetrends <- function(dt = comparecube,
   plotdata <- collapse::join(allyears, d, on = c("GEOniv", "AAR", "variable"), how = "left", multiple = T, verbose = 0, overid = 0)
   xsize <- ifelse(length(unique(plotdata$AAR)) > 12, 10, 20)
   savepath <- get_plotsavefolder(cubename, "Diff_timetrends")
-  if(save) archive_old_files(savepath, cubefile)
+  if(save) archive_old_files(savepath, cubename)
 
   for(geoniv in unique(d$GEOniv)){
     subset <- plotdata[GEOniv == geoniv]

--- a/R/check-geolevel.R
+++ b/R/check-geolevel.R
@@ -59,6 +59,7 @@ compare_geolevels <- function(dt = newcube,
   d[, (groupdims) := lapply(.SD, as.factor), .SDcols = groupdims]
   d[, (c(outcols, "Absolute")) := lapply(.SD, round, 0), .SDcols = c(outcols, "Absolute")]
   data.table::setorder(d, -Relative, na.last = T)
+  if(any(d$Absolute < 0)) cat("For some rows, lower GEOlevel > higher GEOlevel, see rows where Absolute < 0!!")
   return(tab_output(d, nosearchcolumns = outcols))
 }
 

--- a/R/check-geolevel.R
+++ b/R/check-geolevel.R
@@ -59,7 +59,7 @@ compare_geolevels <- function(dt = newcube,
   d[, (groupdims) := lapply(.SD, as.factor), .SDcols = groupdims]
   d[, (c(outcols, "Absolute")) := lapply(.SD, round, 0), .SDcols = c(outcols, "Absolute")]
   data.table::setorder(d, -Relative, na.last = T)
-  if(any(d$Absolute < 0)) cat("For some rows, lower GEOlevel > higher GEOlevel, see rows where Absolute < 0!!")
+  if(any(d$Absolute[!is.na(d$Absolute)] < 0)) cat("For some rows, lower GEOlevel > higher GEOlevel, see rows where Absolute < 0!!")
   return(tab_output(d, nosearchcolumns = outcols))
 }
 

--- a/R/make_comparecube.R
+++ b/R/make_comparecube.R
@@ -233,7 +233,7 @@ add_outlier <- function(dt,
     outliercol <- paste0("change_", outliercol)
   }
 
-  dt <- collapse::join(dt, cutoffs, on = by, overid = 0, verbose = 0)
+  dt <- collapse::join(dt, cutoffs, on = by, verbose = 0, overid = 0)
   dt[get(val) > get(highcutoff), (outliercol) := 1]
   dt[get(val) < get(lowcutoff), (outliercol) := 1]
   dt[get(val) > get(lowcutoff) & get(val) < get(highcutoff), (outliercol) := 0]

--- a/R/plot_boxplot.R
+++ b/R/plot_boxplot.R
@@ -33,7 +33,7 @@ plot_boxplot <- function(dt = newcube_flag,
                                        MINABOVELOW = collapse::fmin(get(plotvalue)[get(plotvalue) >= get(limits[1])]),
                                        MAXBELOWHIGH = collapse::fmax(get(plotvalue)[get(plotvalue) <= get(limits[2])])),
                                    by = bycols],
-                                 overid = 0, verbose = 0)
+                                 verbose = 0, overid = 0)
   baseplotdata[, (limits) := NULL]
 
   # Extract outlierdata

--- a/R/plot_boxplot.R
+++ b/R/plot_boxplot.R
@@ -64,7 +64,7 @@ plot_boxplot <- function(dt = newcube_flag,
   n_rows <- ceiling(nrow(plotargs$allplotdims[, .N, by = panels])/5)
   folder <- ifelse(change, "Boxplot_change", "Boxplot")
   savepath <- get_plotsavefolder(cubename, folder)
-  if(save) archive_old_files(savepath, cubefile)
+  if(save) archive_old_files(savepath, cubename)
 
   for(i in filter){
     if(save) cat("\nSaving file", which(filter == i), "/", length(filter))

--- a/R/plot_boxplot.R
+++ b/R/plot_boxplot.R
@@ -67,7 +67,7 @@ plot_boxplot <- function(dt = newcube_flag,
   if(save) archive_old_files(savepath, cubefile)
 
   for(i in filter){
-    cat("\nSaving file", which(filter == i), "/", length(filter))
+    if(save) cat("\nSaving file", which(filter == i), "/", length(filter))
     bp <- baseplotdata[eval(parse(text = i))][N_obs > 2]
     ol <- outlierdata[eval(parse(text = i))]
 
@@ -78,7 +78,8 @@ plot_boxplot <- function(dt = newcube_flag,
           plotargs$subtitle_full <- paste0(plotargs$subtitle_full, "\n", i, ": ", unique(bp[[i]]))
         }
       plot <- plot_boxplot_plotfun(bp, ol, plotargs)
-    if(save) plot_boxplot_savefun(plot, savepath, cubefile, suffix, n_rows)
+      if(save) plot_boxplot_savefun(plot, savepath, cubefile, suffix, n_rows)
+      print(plot)
     }
   }
 }

--- a/R/plot_timeseries.R
+++ b/R/plot_timeseries.R
@@ -82,7 +82,7 @@ plot_timeseries <- function(dt = newcube_flag,
     d_line <- linedata[page == i]
     if(nrow(d_plot) > 0){
       geosuffix <- paste0(min(d_plot$GEO), "-", max(d_plot$GEO))
-      plot <- plot_timeseries_plotfun(d_plot, d_outlier, d_line, plotargs)
+      plot <- plot_timeseries_plotfun(d_plot, d_outlier, d_line, plotargs, geosuffix)
       if(save) plot_timeseries_savefun(plot, savepath, cubefile, geosuffix)
     }
   }
@@ -96,7 +96,8 @@ plot_timeseries <- function(dt = newcube_flag,
 plot_timeseries_plotfun <- function(d_plot,
                                     d_outlier,
                                     d_line,
-                                    plotargs){
+                                    plotargs,
+                                    geosuffix){
 
   plot <- ggplot2::ggplot(d_plot,
                           ggplot2::aes(x = AAR, y = get(plotargs$plotvalue))) +
@@ -140,7 +141,7 @@ plot_timeseries_plotfun <- function(d_plot,
     ggplot2::labs(title = plotargs$title,
                   y = plotargs$ylab,
                   caption = plotargs$caption,
-                  subtitle = paste0(plotargs$subtitle, "\nGEO codes: ", plotargs$geosuffix)) +
+                  subtitle = paste0(plotargs$subtitle, "\nGEO codes: ", geosuffix)) +
     ggplot2::theme(axis.text.x = ggplot2::element_text(angle = 90, vjust = 0.5))
 
 

--- a/R/plot_timeseries.R
+++ b/R/plot_timeseries.R
@@ -48,7 +48,7 @@ plot_timeseries <- function(dt = newcube_flag,
 
   # Split into multiple files with max 25 panels per file
   pageinfo <- plot_timeseries_filesplit(d, bycols)
-  d <- collapse::join(d, pageinfo, on = bycols, how = "left", multiple = T, overid = 0, verbose = 0)
+  d <- collapse::join(d, pageinfo, on = bycols, how = "left", multiple = T, verbose = 0, overid = 0)
   outlierdata <- d[get(outlier) == 1]
   if(onlynew & isnewoutlier){
     outlierdata[, label := factor(data.table::fcase(get(newoutlier) == 0, "Previous outlier",

--- a/R/plot_timeseries.R
+++ b/R/plot_timeseries.R
@@ -73,7 +73,7 @@ plot_timeseries <- function(dt = newcube_flag,
   n_pages <- max(d$page)
   folder <- ifelse(change, "TimeSeries_change", "TimeSeries")
   savepath <- get_plotsavefolder(cubename, folder)
-  if(save) archive_old_files(savepath, cubefile)
+  if(save) archive_old_files(savepath, cubename)
 
   for(i in 1:n_pages){
     cat("\nSaving file", i, "/", n_pages)

--- a/R/plot_timeseries_bydel.R
+++ b/R/plot_timeseries_bydel.R
@@ -53,9 +53,9 @@ plot_timeseries_bydel <- function(dt = newcube_flag,
       }
     plot <- plot_timeseries_bydel_plotfun(plotdata, trenddata, plotargs)
     if(save) plot_timeseries_bydel_savefun(plot, savepath, cubefile, suffix, rows)
+    print(plot)
     }
   }
-  return(plot)
 }
 
 #' @title plot_boxplot_plotfun

--- a/R/plot_timeseries_bydel.R
+++ b/R/plot_timeseries_bydel.R
@@ -38,7 +38,7 @@ plot_timeseries_bydel <- function(dt = newcube_flag,
   plotargs$anyrows <- ifelse(length(panels) > 0, 1, 0)
   rows <- nrow(plotargs$allplotdims[, .N, by = allpanels])
   savepath <- get_plotsavefolder(cubename, "TimeSeries_bydel")
-  if(save) archive_old_files(savepath, cubefile)
+  if(save) archive_old_files(savepath, cubename)
 
   for(i in filter){
     cat("\nSaving file", which(filter == i), "/", length(filter))

--- a/R/plot_timeseries_country.R
+++ b/R/plot_timeseries_country.R
@@ -38,6 +38,7 @@ plot_timeseries_country <- function(dt = newcube,
     if(dim == "Total") plotdata[, let(Total = "total")]
     plot <- plot_timeseries_country_plotfun(plotdata, dim)
     plot_timeseries_country_savefun(plot, savepath, dim, cubefile, plotrows, save = save)
+    print(plot)
   }
 }
 

--- a/R/plot_timeseries_country.R
+++ b/R/plot_timeseries_country.R
@@ -25,7 +25,7 @@ plot_timeseries_country <- function(dt = newcube,
   d[, (plotdims) := lapply(.SD, as.factor), .SDcols = plotdims]
 
   savepath <- get_plotsavefolder(cubename, "TimeSeries_country")
-  if(save) archive_old_files(savepath, cubefile)
+  if(save) archive_old_files(savepath, cubename)
 
   for(dim in c("Total", plotdims)){
     if(dim == "Total") plotdata <- aggregate_cube_multi(d, plotdims)

--- a/R/read-files.R
+++ b/R/read-files.R
@@ -128,7 +128,7 @@ read_cube <- function(filepath, type = c("New", "Old")){
   data.table::setattr(dt, "colnameinfo", list(orgnames = .orgnames, newnames = .newnames, diff = .diff))
   cat(paste0("\n", type, " cube loaded: ", sub("(.*PRODUKTER/)", "", filepath), "\n"))
   if(.diff == "yes"){list_renamecols(.orgnames, .newnames, type)}
-  if(type == "New"){is_valid_outcols(dt)}
+  if(type == "New" && grepl("ikkegeoprikket_", attributes(dt)$Filename)){is_valid_outcols(dt)}
 
   return(dt)
 }

--- a/R/read-files.R
+++ b/R/read-files.R
@@ -161,7 +161,7 @@ recode_geo <- function(dt, recode){
   recodings <- .georecode[old %in% dt$GEO][order(old)]
   if(nrow(recodings > 0)) cat(paste0("\nIn ", cubeversion, " cube: Recoding ", nrow(recodings), " geographical codes to ", geoyear, "-codes"))
 
-  d <- collapse::join(dt, .georecode, on = c("GEO" = "old"), how = "left", verbose = 0)
+  d <- collapse::join(dt, .georecode, on = c("GEO" = "old"), how = "left", verbose = 0, overid = 0)
   d[, let(origgeo = GEO)]
   d[!is.na(current), let(GEO = current)]
   d[, let(current = NULL)]


### PR DESCRIPTION
### New features

1. `plot_boxplot()`, `plot_timeseries_country()`, `plot_timeseries_bydel()`, and `plot_diff_timetrends()` now prints the plot in the console.
2. `compare_geolevels()` prints a message if lower geographical level > higher geographical level, e.g. kommune > fylke. 

### Bugfixes

1. `add_changeval()` adds a small constant equal to half of the minimum non-zero value of the outlier variable. This prevents Inf-values for change variables in the flagged cube.
2. `plot_timeseries()` correctly shows GEO-codes in the plots
3. In plotting functions, `archive_old_files()` now matches on cube name and not cube file (including date tag) to archive all old files
4. Bug fixed in `compare_geolevels()` where missing data interfered with checking if any lower level > higher level. 
5. `is_valid_outcols()` only applied if data file is not censored on geo.
6. In all functions using collapse::join, overid is set to 0 to prevent overidentification of joins. 